### PR TITLE
fix: Compilation on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,18 +134,28 @@ if(UNIX)
   set(Boost_USE_STATIC_LIBS ON)
   find_package(Boost COMPONENTS filesystem system REQUIRED)
   find_package(Boost COMPONENTS thread REQUIRED)
-  add_definitions(-std=c++11)
+  add_definitions(-std=c++17)
   add_definitions(-D_FILE_OFFSET_BITS=64)
   set(WARNING "-Wall -Wextra -Werror -pedantic -pedantic-errors")
+  string(APPEND WARNING " -Wno-deprecated-declarations") # Because 'gcry_thread_cbs' looks deprecated.
+  string(APPEND WARNING " -Wno-gnu-zero-variadic-macro-arguments") #  Google tests use no arg for '...' variadic macro
   set(CMAKE_CXX_FLAGS "${CMAKE_THREAD_LIBS_INIT} ${WARNING} ${CMAKE_CXX_FLAGS}")
   include_directories(${CMAKE_SOURCE_DIR}/blobfuse ${CMAKE_SOURCE_DIR}/azure-storage-cpp-lite/include ${CURL_INCLUDE_DIRS} ${GNUTLS_INCLUDE_DIR} ${Boost_INCLUDE_DIR} nlohmann-json)
+
+  set(FUSE_LIBRARY fuse)
+  if (${APPLE})
+    # Default installation path of oxsfuse (https://osxfuse.github.io/).
+    include_directories(/usr/local/include/osxfuse)
+    link_directories(/usr/local/lib)
+    set(FUSE_LIBRARY osxfuse)
+  endif()
 
   set(CMAKE_MACOSX_RPATH ON)
 
   add_executable(blobfuse ${BLOBFUSE_HEADER} ${BLOBFUSE_SOURCE} ${AZURE_STORAGE_HEADER} ${AZURE_STORAGE_SOURCE} blobfuse/main.cpp)
 
   pkg_search_module(UUID REQUIRED uuid)
-  target_link_libraries(blobfuse ${CURL_LIBRARIES} ${GNUTLS_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${UUID_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} fuse gcrypt)
+  target_link_libraries(blobfuse ${CURL_LIBRARIES} ${GNUTLS_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${UUID_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} ${FUSE_LIBRARY} gcrypt)
   install(TARGETS blobfuse
     PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
     DESTINATION bin)
@@ -226,6 +236,6 @@ if(INCLUDE_TESTS)
   pkg_search_module(UUID REQUIRED uuid)
   include_directories(${Boost_INCLUDE_DIR})
   add_executable(blobfusetests ${BLOBFUSE_HEADER} ${BLOBFUSE_SOURCE} ${AZURE_STORAGE_HEADER} ${AZURE_STORAGE_SOURCE} blobfuse/blobfuse.cpp test/cpplitetests.cpp test/attribcachetests.cpp test/attribcachesynchronizationtests.cpp)
-  target_link_libraries(blobfusetests ${CURL_LIBRARIES} ${GNUTLS_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${UUID_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} fuse gcrypt gmock_main)
+  target_link_libraries(blobfusetests ${CURL_LIBRARIES} ${GNUTLS_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${UUID_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} ${FUSE_LIBRARY} gcrypt gmock_main)
 
 endif()

--- a/blobfuse/blobfuse.h
+++ b/blobfuse/blobfuse.h
@@ -382,10 +382,20 @@ int azs_chown(const char *path, uid_t uid, gid_t gid);
 int azs_chmod(const char *path, mode_t mode);
 int azs_utimens(const char *path, const struct timespec ts[2]);
 int azs_truncate(const char *path, off_t off);
-int azs_setxattr(const char *path, const char *name, const char *value, size_t size, int flags);
 
 /** Not implemented. */
+#ifdef __APPLE__
+int azs_setxattr(const char *path, const char *name, const char *value, size_t size, int flags, uint32_t);
+#else
+int azs_setxattr(const char *path, const char *name, const char *value, size_t size, int flags);
+#endif // __APPLE__
+
+/** Not implemented. */
+#ifdef __APPLE__
+int azs_getxattr(const char *path, const char *name, char *value, size_t size, uint32_t);
+#else
 int azs_getxattr(const char *path, const char *name, char *value, size_t size);
+#endif // __APPLE__
 
 /** Not implemented. */
 int azs_listxattr(const char *path, char *list, size_t size);

--- a/blobfuse/fileapis.cpp
+++ b/blobfuse/fileapis.cpp
@@ -192,7 +192,6 @@ int azs_read(const char *path, char *buf, size_t size, off_t offset, struct fuse
 
     return res;
 }
-#pragma GCC diagnostic pop
 
 // Note that in FUSE, create is not the same as open with specific flags (the way it is in Linux)
 // See the FUSE docs on these methods for more details.
@@ -258,8 +257,6 @@ int azs_write(const char *path, const char *buf, size_t size, off_t offset, stru
     return res;
 }
 
-#pragma GCC diagnostic pop
-
 int azs_flush(const char *path, struct fuse_file_info *fi)
 {
     AZS_DEBUGLOGV("azs_flush called with path = %s, fi->flags = %d, (((struct fhwrapper *)fi->fh)->fh) = %d.\n", path, fi->flags, (((struct fhwrapper *)fi->fh)->fh));
@@ -271,8 +268,8 @@ int azs_flush(const char *path, struct fuse_file_info *fi)
     char path_link_buffer[50];
     snprintf(path_link_buffer, 50, "/proc/self/fd/%d", (((struct fhwrapper *)fi->fh)->fh));
 
-    // canonicalize_file_name will follow symlinks to give the actual path name.
-    char *path_buffer = canonicalize_file_name(path_link_buffer);
+    // Follow symlinks to give the actual path name.
+    char *path_buffer = realpath(path_link_buffer, nullptr);
     if (path_buffer == NULL)
     {
         AZS_DEBUGLOGV("Skipped blob upload in azs_flush with input path %s because file no longer exists.\n", path);

--- a/blobfuse/utilities.cpp
+++ b/blobfuse/utilities.cpp
@@ -739,12 +739,20 @@ int azs_rename(const char *src, const char *dst)
     return 0;
 }
 
-
+#ifdef __APPLE__
+int azs_setxattr(const char * /*path*/, const char * /*name*/, const char * /*value*/, size_t /*size*/, int /*flags*/, uint32_t)
+#else
 int azs_setxattr(const char * /*path*/, const char * /*name*/, const char * /*value*/, size_t /*size*/, int /*flags*/)
+#endif // __APPLE__
 {
     return -ENOSYS;
 }
+
+#ifdef __APPLE__
+int azs_getxattr(const char * /*path*/, const char * /*name*/, char * /*value*/, size_t /*size*/, uint32_t)
+#else
 int azs_getxattr(const char * /*path*/, const char * /*name*/, char * /*value*/, size_t /*size*/)
+#endif // __APPLE__
 {
     return -ENOSYS;
 }


### PR DESCRIPTION
This commit makes all target compiles successfully using:

- clang-10 installed using brew
- oxsfuse available here: https://osxfuse.github.io/

What is mandatory:

- Ignoring deprecated warnings because of gcry_thread_cbs is used but is
  deprecated (at least in my version of libgcrypt);
- Adding a parameter typed `uint32_t` to get and set xattr fuse
  operations.
- Setting the path to osxfuse headers and libraries because it isn't
  installed in the default location searched by cmake.
- Using realpath instead of canonicalize_file_name which is a GNU
  extencion apparently not known on macOS.
- Removing wrong pragma pop instruction as the preceding pragmas are not
  push pragmas.

What is optional:

- Moving to C++17... But let's be modern!